### PR TITLE
Fix endcity string name

### DIFF
--- a/src/main/java/kaptainwutax/featureutils/structure/EndCity.java
+++ b/src/main/java/kaptainwutax/featureutils/structure/EndCity.java
@@ -29,7 +29,7 @@ public class EndCity extends TriangularStructure<EndCity> implements ILoot {
 	}
 
 	public static String name() {
-		return "end_city";
+		return "endcity";
 	}
 
 	@Override

--- a/src/main/java/kaptainwutax/featureutils/structure/Structure.java
+++ b/src/main/java/kaptainwutax/featureutils/structure/Structure.java
@@ -20,7 +20,7 @@ public abstract class Structure<C extends Feature.Config, D extends Feature.Data
 		CLASS_TO_NAME.put(BastionRemnant.class, "bastion_remnant");
 		CLASS_TO_NAME.put(BuriedTreasure.class, "buried_treasure");
 		CLASS_TO_NAME.put(DesertPyramid.class, "desert_pyramid");
-		CLASS_TO_NAME.put(EndCity.class, "end_city");
+		CLASS_TO_NAME.put(EndCity.class, "endcity");
 		CLASS_TO_NAME.put(Fortress.class, "fortress");
 		CLASS_TO_NAME.put(Igloo.class, "igloo");
 		CLASS_TO_NAME.put(JunglePyramid.class, "jungle_pyramid");


### PR DESCRIPTION
The string name for an end city in FeatureUtils does not match Minecraft's string name. This is a QOL improvement for projects using FeatureUtils along with Minecraft.