### PR TITLE
Fix ore decorator block replace checks

### DIFF
--- a/src/main/java/kaptainwutax/featureutils/decorator/ore/RegularOreDecorator.java
+++ b/src/main/java/kaptainwutax/featureutils/decorator/ore/RegularOreDecorator.java
@@ -122,7 +122,7 @@ public abstract class RegularOreDecorator<C extends OreDecorator.Config, D exten
 										if(!bitSet.get(area)) {
 											bitSet.set(area);
 											BPos pos = new BPos(X, Y, Z);
-											if(generator.getDefaultBlock().equals(generator.getBlockAt(pos).orElse(Blocks.AIR))) {
+											if(this.getReplaceBlocks(biome).contains(generator.getBlockAt(pos).orElse(Blocks.AIR))) {
 												poses.add(pos);
 											}
 										}

--- a/src/main/java/kaptainwutax/featureutils/decorator/ore/ScatterOreDecorator.java
+++ b/src/main/java/kaptainwutax/featureutils/decorator/ore/ScatterOreDecorator.java
@@ -30,7 +30,7 @@ public abstract class ScatterOreDecorator<C extends OreDecorator.Config, D exten
 
 		for(int i = 0; i < count; ++i) {
 			BPos startPos = this.getStartPos(rand, bPos, Math.min(i, 7));
-			if(generator.getDefaultBlock().equals(generator.getBlockAt(startPos).orElse(Blocks.AIR)) && !this.checkAir(generator, startPos)) {
+			if(this.getReplaceBlocks(biome).contains(generator.getBlockAt(startPos).orElse(Blocks.AIR)) && !this.checkAir(generator, startPos)) {
 				poses.add(startPos);
 			}
 		}

--- a/src/main/java/kaptainwutax/featureutils/decorator/ore/SphereOreDecorator.java
+++ b/src/main/java/kaptainwutax/featureutils/decorator/ore/SphereOreDecorator.java
@@ -38,10 +38,8 @@ public abstract class SphereOreDecorator<C extends OreDecorator.Config, D extend
 					for(int y = bPos.getY() - this.getSize(biome); y <= bPos.getY() + this.getSize(biome); y++) {
 						BPos currentPos = new BPos(x, y, z);
 						Block current = generator.getBiomeColumnAt(x, z)[y];
-						for(Block block : this.getReplaceBlocks(biome)) {
-							if(current.equals(block)) {
-								poses.add(currentPos);
-							}
+						if(this.getReplaceBlocks(biome).contains(current)) {
+							poses.add(currentPos);
 						}
 					}
 				}


### PR DESCRIPTION
Ore decorators should use this.getReplaceBlocks() to check if they can generate at that position.
This PR replaces generator.getDefaultBlock().equals(block) with this.getReplaceBlocks(biome).contains(block)