### PR TITLE
optimize loot generation by preprocessing (and fix Enchantments in the meantime)

### DIFF
--- a/src/main/java/kaptainwutax/featureutils/loot/LootPool.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/LootPool.java
@@ -32,7 +32,7 @@ public class LootPool extends LootGenerator {
 		return this;
 	}
 
-	public LootPool apply(MCVersion version) {
+	public LootPool apply(MCVersion version, int luck) {
 		this.lootEntries = Arrays.stream(lootEntries).filter(lootEntry -> {
 			// remove the entry if it was not yet introduced yet (so older and not equal to the introduced version)
 			if(lootEntry.introducedVersion != null) {
@@ -50,14 +50,14 @@ public class LootPool extends LootGenerator {
 		totalWeight = 0;
 
 		for (LootEntry entry : this.lootEntries) {
-			totalWeight += Math.max(entry.weight + entry.quality, 0);
+			totalWeight += entry.getEffectiveWeight(luck);
 		}
 
 		optimizationArray = new LootEntry[totalWeight];
 
 		int k = 0;
 		for (LootEntry entry : this.lootEntries) {
-			int weight = Math.max(entry.weight + entry.quality, 0);
+			int weight =  entry.getEffectiveWeight(luck);
 			for (int i = 0; i < weight; i++) {
 				optimizationArray[k + i] = entry;
 			}

--- a/src/main/java/kaptainwutax/featureutils/loot/LootPool.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/LootPool.java
@@ -1,5 +1,6 @@
 package kaptainwutax.featureutils.loot;
 
+import kaptainwutax.featureutils.loot.entry.ItemEntry;
 import kaptainwutax.featureutils.loot.entry.LootEntry;
 import kaptainwutax.featureutils.loot.function.LootFunction;
 import kaptainwutax.featureutils.loot.item.ItemStack;
@@ -17,6 +18,8 @@ public class LootPool extends LootGenerator {
 
 	public final LootRoll rolls;
 	public LootEntry[] lootEntries;
+	public int totalWeight;
+	public LootEntry[] optimizationArray;
 	public final LootRoll bonusRolls = new UniformRoll(0.0F, 0.0F);
 
 	public LootPool(LootRoll rolls, LootEntry... lootEntries) {
@@ -43,6 +46,24 @@ public class LootPool extends LootGenerator {
 			}
 			return true;
 		}).toArray(LootEntry[]::new);
+
+		totalWeight = 0;
+
+		for (LootEntry entry : this.lootEntries) {
+			totalWeight += Math.max(entry.weight + entry.quality, 0);
+		}
+
+		optimizationArray = new LootEntry[totalWeight];
+
+		int k = 0;
+		for (LootEntry entry : this.lootEntries) {
+			int weight = Math.max(entry.weight + entry.quality, 0);
+			for (int i = 0; i < weight; i++) {
+				optimizationArray[k + i] = entry;
+			}
+			k += weight;
+		}
+
 		return this;
 	}
 
@@ -67,51 +88,14 @@ public class LootPool extends LootGenerator {
 	}
 
 	private void generatePool13(LootContext context, Consumer<ItemStack> stackConsumer) {
-		int totalWeight = 0;
-		List<LootEntry> entries = new ArrayList<>();
-		for(LootEntry lootEntry : this.lootEntries) {
-			// we assume no conditions here
-			int weight = lootEntry.getEffectiveWeight(context);
-			if(weight > 0) {
-				entries.add(lootEntry);
-				totalWeight += weight;
-			}
-		}
-
-		if(totalWeight != 0 && !entries.isEmpty()) {
-			int count = context.nextInt(totalWeight);
-			for(LootEntry entry : entries) {
-				count -= entry.getEffectiveWeight(context);
-				if(count < 0) {
-					entry.generate(context, stackConsumer);
-					return;
-				}
-			}
-		}
+		this.optimizationArray[context.nextInt(totalWeight)].generate(context, stackConsumer);
 	}
 
 	private void generatePool14(LootContext context, Consumer<ItemStack> stackConsumer) {
-		int totalWeight = 0;
-		for(LootEntry lootEntry : this.lootEntries) {
-			totalWeight += lootEntry.getEffectiveWeight(context);
-		}
-
-		if(this.lootEntries.length == 1) {
+		if (this.lootEntries.length == 1) {
 			this.lootEntries[0].generate(context, stackConsumer);
-			return;
-		}
-
-		int i = context.nextInt(totalWeight);
-		LootEntry pickedEntry = null;
-
-		for(LootEntry lootEntry : this.lootEntries) {
-			pickedEntry = lootEntry;
-			i -= lootEntry.getWeight(context);
-			if(i < 0) break;
-		}
-
-		if(pickedEntry != null) {
-			pickedEntry.generate(context, stackConsumer);
+		} else {
+			this.optimizationArray[context.nextInt(this.totalWeight)].generate(context, stackConsumer);
 		}
 	}
 

--- a/src/main/java/kaptainwutax/featureutils/loot/LootTable.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/LootTable.java
@@ -33,9 +33,13 @@ public class LootTable extends LootGenerator {
 		this.apply(lootFunctions);
 	}
 
-	public LootTable apply(MCVersion version) {
+	public LootTable apply(MCVersion version){
+		return apply(version, 1);
+	}
+
+	public LootTable apply(MCVersion version, int luck) {
 		for(LootPool lootPool : this.lootPools) {
-			lootPool.apply(version);
+			lootPool.apply(version, luck);
 		}
 		Enchantments.apply(version);
 		hasVersionApplied = true;
@@ -108,7 +112,7 @@ public class LootTable extends LootGenerator {
 	public void generate(LootContext context, Consumer<ItemStack> stackConsumer) {
 		if(!hasVersionApplied) {
 			System.err.println("Version was not applied, we default to latest " + MCVersion.latest());
-			this.apply(MCVersion.latest());
+			this.apply(MCVersion.latest(), context.getLuck());
 			hasVersionApplied = true;
 		}
 		stackConsumer = LootFunction.stack(stackConsumer, this.combinedLootFunction, context);

--- a/src/main/java/kaptainwutax/featureutils/loot/LootTable.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/LootTable.java
@@ -1,5 +1,6 @@
 package kaptainwutax.featureutils.loot;
 
+import kaptainwutax.featureutils.loot.enchantment.Enchantments;
 import kaptainwutax.featureutils.loot.function.LootFunction;
 import kaptainwutax.featureutils.loot.item.Item;
 import kaptainwutax.featureutils.loot.item.ItemStack;
@@ -36,6 +37,7 @@ public class LootTable extends LootGenerator {
 		for(LootPool lootPool : this.lootPools) {
 			lootPool.apply(version);
 		}
+		Enchantments.apply(version);
 		hasVersionApplied = true;
 		return this;
 	}

--- a/src/main/java/kaptainwutax/featureutils/loot/MCLootTables.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/MCLootTables.java
@@ -1,5 +1,11 @@
 package kaptainwutax.featureutils.loot;
 
+import static kaptainwutax.featureutils.loot.function.SetCountFunction.constant;
+import static kaptainwutax.featureutils.loot.function.SetCountFunction.uniform;
+
+
+import kaptainwutax.featureutils.loot.LootPool;
+import kaptainwutax.featureutils.loot.LootTable;
 import kaptainwutax.featureutils.loot.effect.Effects;
 import kaptainwutax.featureutils.loot.entry.EmptyEntry;
 import kaptainwutax.featureutils.loot.entry.ItemEntry;
@@ -12,9 +18,6 @@ import kaptainwutax.featureutils.loot.roll.ConstantRoll;
 import kaptainwutax.featureutils.loot.roll.UniformRoll;
 import kaptainwutax.mcutils.version.MCVersion;
 
-import static kaptainwutax.featureutils.loot.function.SetCountFunction.constant;
-import static kaptainwutax.featureutils.loot.function.SetCountFunction.uniform;
-
 @SuppressWarnings("unused")
 public class MCLootTables {
 
@@ -25,7 +28,7 @@ public class MCLootTables {
 			new ItemEntry(Items.GOLDEN_APPLE, 20),
 			new ItemEntry(Items.ENCHANTED_GOLDEN_APPLE),
 			new ItemEntry(Items.NAME_TAG, 30),
-			new ItemEntry(Items.ENCHANTED_BOOK, 10).apply(new EnchantRandomlyFunction()),
+			new ItemEntry(Items.ENCHANTED_BOOK, 10).apply(new EnchantRandomlyFunction(Items.ENCHANTED_BOOK)),
 			new ItemEntry(Items.IRON_PICKAXE, 5),
 			new EmptyEntry(5)),
 		new LootPool(new UniformRoll(2.0F, 4.0F),
@@ -53,7 +56,7 @@ public class MCLootTables {
 		new LootPool(new ConstantRoll(1),
 			new ItemEntry(Items.LODESTONE).apply(constant(1))),
 		new LootPool(new UniformRoll(1.0F, 2.0F),
-			new ItemEntry(Items.CROSSBOW).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction()),
+			new ItemEntry(Items.CROSSBOW).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction(Items.CROSSBOW)),
 			new ItemEntry(Items.SPECTRAL_ARROW).apply(uniform(2.0F, 12.0F)),
 			new ItemEntry(Items.GILDED_BLACKSTONE).apply(uniform(5.0F, 8.0F)),
 			new ItemEntry(Items.CRYING_OBSIDIAN).apply(uniform(3.0F, 8.0F)),
@@ -61,10 +64,10 @@ public class MCLootTables {
 			new ItemEntry(Items.GOLD_INGOT).apply(uniform(2.0F, 8.0F)),
 			new ItemEntry(Items.IRON_INGOT).apply(uniform(2.0F, 8.0F)),
 			new ItemEntry(Items.GOLDEN_SWORD).apply(constant(1)),
-			new ItemEntry(Items.GOLDEN_CHESTPLATE).apply(constant(1)).apply(new EnchantRandomlyFunction()),
-			new ItemEntry(Items.GOLDEN_HELMET).apply(constant(1)).apply(new EnchantRandomlyFunction()),
-			new ItemEntry(Items.GOLDEN_LEGGINGS).apply(constant(1)).apply(new EnchantRandomlyFunction()),
-			new ItemEntry(Items.GOLDEN_BOOTS).apply(constant(1)).apply(new EnchantRandomlyFunction())),
+			new ItemEntry(Items.GOLDEN_CHESTPLATE).apply(constant(1)).apply(new EnchantRandomlyFunction(Items.GOLDEN_CHESTPLATE)),
+			new ItemEntry(Items.GOLDEN_HELMET).apply(constant(1)).apply(new EnchantRandomlyFunction(Items.GOLDEN_HELMET)),
+			new ItemEntry(Items.GOLDEN_LEGGINGS).apply(constant(1)).apply(new EnchantRandomlyFunction(Items.GOLDEN_LEGGINGS)),
+			new ItemEntry(Items.GOLDEN_BOOTS).apply(constant(1)).apply(new EnchantRandomlyFunction(Items.GOLDEN_BOOTS))),
 		new LootPool(new UniformRoll(2.0F, 4.0F),
 			new ItemEntry(Items.STRING).apply(uniform(1.0F, 6.0F)),
 			new ItemEntry(Items.LEATHER).apply(uniform(1.0F, 3.0F)),
@@ -75,12 +78,12 @@ public class MCLootTables {
 
 	public static final LootTable BASTION_HOGLIN_STABLE_CHEST = new LootTable(
 		new LootPool(new ConstantRoll(1),
-			new ItemEntry(Items.DIAMOND_SHOVEL, 5).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction()),
+			new ItemEntry(Items.DIAMOND_SHOVEL, 5).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction(Items.DIAMOND_SHOVEL)),
 			new ItemEntry(Items.NETHERITE_SCRAP, 2).apply(constant(1)),
 			new ItemEntry(Items.ANCIENT_DEBRIS, 3).apply(constant(1)),
 			new ItemEntry(Items.SADDLE, 10).apply(constant(1)),
 			new ItemEntry(Items.GOLD_BLOCK, 25).apply(uniform(2.0F, 4.0F)),
-			new ItemEntry(Items.GOLDEN_HOE, 15).apply(constant(1)).apply(new EnchantRandomlyFunction()),
+			new ItemEntry(Items.GOLDEN_HOE, 15).apply(constant(1)).apply(new EnchantRandomlyFunction(Items.GOLDEN_HOE)),
 			new EmptyEntry(45)),
 		new LootPool(new UniformRoll(3.0F, 4.0F),
 			new ItemEntry(Items.GLOWSTONE).apply(uniform(1.0F, 5.0F)),
@@ -99,16 +102,16 @@ public class MCLootTables {
 
 	public static final LootTable BASTION_OTHER_CHEST = new LootTable(
 		new LootPool(new ConstantRoll(1),
-			new ItemEntry(Items.CROSSBOW, 12).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction()),
+			new ItemEntry(Items.CROSSBOW, 12).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction(Items.CROSSBOW)),
 			new ItemEntry(Items.ANCIENT_DEBRIS, 2).apply(constant(1)),
 			new ItemEntry(Items.NETHERITE_SCRAP, 2).apply(constant(1)),
 			new ItemEntry(Items.SPECTRAL_ARROW, 16).apply(uniform(2.0F, 15.0F)),
 			new ItemEntry(Items.PIGLIN_BANNER_PATTERN, 5).apply(constant(1)),
 			new ItemEntry(Items.MUSIC_DISC_PIGSTEP, 3).apply(constant(1)),
-			new ItemEntry(Items.ENCHANTED_BOOK, 10).apply(new EnchantRandomlyFunction(true, false)),
+			new ItemEntry(Items.ENCHANTED_BOOK, 10).apply(new EnchantRandomlyFunction(Items.ENCHANTED_BOOK, true, false)),
 			new EmptyEntry(50)),
 		new LootPool(new ConstantRoll(2),
-			new ItemEntry(Items.GOLDEN_BOOTS).apply(constant(1)).apply(new EnchantRandomlyFunction(true, false)),
+			new ItemEntry(Items.GOLDEN_BOOTS).apply(constant(1)).apply(new EnchantRandomlyFunction(Items.GOLDEN_BOOTS, true, false)),
 			new ItemEntry(Items.GOLD_BLOCK).apply(constant(1)),
 			new ItemEntry(Items.CROSSBOW).apply(constant(1)),
 			new ItemEntry(Items.GOLD_INGOT).apply(uniform(1.0F, 6.0F)),
@@ -138,11 +141,11 @@ public class MCLootTables {
 			new ItemEntry(Items.ANCIENT_DEBRIS, 14).apply(constant(1)),
 			new ItemEntry(Items.NETHERITE_SCRAP, 10).apply(constant(1)),
 			new ItemEntry(Items.ANCIENT_DEBRIS).apply(constant(2)),
-			new ItemEntry(Items.DIAMOND_SWORD, 10).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction()),
-			new ItemEntry(Items.DIAMOND_CHESTPLATE, 6).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction()),
-			new ItemEntry(Items.DIAMOND_HELMET, 6).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction()),
-			new ItemEntry(Items.DIAMOND_LEGGINGS, 6).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction()),
-			new ItemEntry(Items.DIAMOND_BOOTS, 6).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction()),
+			new ItemEntry(Items.DIAMOND_SWORD, 10).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction(Items.DIAMOND_SWORD)),
+			new ItemEntry(Items.DIAMOND_CHESTPLATE, 6).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction(Items.DIAMOND_CHESTPLATE)),
+			new ItemEntry(Items.DIAMOND_HELMET, 6).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction(Items.DIAMOND_HELMET)),
+			new ItemEntry(Items.DIAMOND_LEGGINGS, 6).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction(Items.DIAMOND_LEGGINGS)),
+			new ItemEntry(Items.DIAMOND_BOOTS, 6).apply(new ApplyDamageFunction(), new EnchantRandomlyFunction(Items.DIAMOND_BOOTS)),
 			new ItemEntry(Items.DIAMOND_SWORD, 6).apply(new ApplyDamageFunction()),
 			new ItemEntry(Items.DIAMOND_CHESTPLATE, 5).apply(new ApplyDamageFunction()),
 			new ItemEntry(Items.DIAMOND_HELMET, 5).apply(new ApplyDamageFunction()),
@@ -193,7 +196,7 @@ public class MCLootTables {
 			new ItemEntry(Items.IRON_HORSE_ARMOR, 15),
 			new ItemEntry(Items.GOLDEN_HORSE_ARMOR, 10),
 			new ItemEntry(Items.DIAMOND_HORSE_ARMOR, 5),
-			new ItemEntry(Items.ENCHANTED_BOOK, 20).apply(new EnchantRandomlyFunction()),
+			new ItemEntry(Items.ENCHANTED_BOOK, 20).apply(new EnchantRandomlyFunction(Items.ENCHANTED_BOOK)),
 			new ItemEntry(Items.GOLDEN_APPLE, 20),
 			new ItemEntry(Items.ENCHANTED_GOLDEN_APPLE, 2),
 			new EmptyEntry(15)),
@@ -216,20 +219,20 @@ public class MCLootTables {
 			new ItemEntry(Items.IRON_HORSE_ARMOR),
 			new ItemEntry(Items.GOLDEN_HORSE_ARMOR),
 			new ItemEntry(Items.DIAMOND_HORSE_ARMOR),
-			new ItemEntry(Items.DIAMOND_SWORD, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.DIAMOND_BOOTS, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.DIAMOND_CHESTPLATE, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.DIAMOND_LEGGINGS, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.DIAMOND_HELMET, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.DIAMOND_PICKAXE, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.DIAMOND_SHOVEL, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.IRON_SWORD, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.IRON_BOOTS, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.IRON_CHESTPLATE, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.IRON_LEGGINGS, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.IRON_HELMET, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.IRON_PICKAXE, 3).apply(new EnchantWithLevelsFunction(20, 39, true)),
-			new ItemEntry(Items.IRON_SHOVEL, 3).apply(new EnchantWithLevelsFunction(20, 39, true)))
+			new ItemEntry(Items.DIAMOND_SWORD, 3).apply(new EnchantWithLevelsFunction(Items.DIAMOND_SWORD,20, 39, true)),
+			new ItemEntry(Items.DIAMOND_BOOTS, 3).apply(new EnchantWithLevelsFunction(Items.DIAMOND_BOOTS, 20, 39, true)),
+			new ItemEntry(Items.DIAMOND_CHESTPLATE, 3).apply(new EnchantWithLevelsFunction(Items.DIAMOND_CHESTPLATE, 20, 39, true)),
+			new ItemEntry(Items.DIAMOND_LEGGINGS, 3).apply(new EnchantWithLevelsFunction(Items.DIAMOND_LEGGINGS, 20, 39, true)),
+			new ItemEntry(Items.DIAMOND_HELMET, 3).apply(new EnchantWithLevelsFunction(Items.DIAMOND_HELMET, 20, 39, true)),
+			new ItemEntry(Items.DIAMOND_PICKAXE, 3).apply(new EnchantWithLevelsFunction(Items.DIAMOND_PICKAXE, 20, 39, true)),
+			new ItemEntry(Items.DIAMOND_SHOVEL, 3).apply(new EnchantWithLevelsFunction(Items.DIAMOND_SHOVEL, 20, 39, true)),
+			new ItemEntry(Items.IRON_SWORD, 3).apply(new EnchantWithLevelsFunction(Items.IRON_SWORD, 20, 39, true)),
+			new ItemEntry(Items.IRON_BOOTS, 3).apply(new EnchantWithLevelsFunction(Items.IRON_BOOTS, 20, 39, true)),
+			new ItemEntry(Items.IRON_CHESTPLATE, 3).apply(new EnchantWithLevelsFunction(Items.IRON_CHESTPLATE, 20, 39, true)),
+			new ItemEntry(Items.IRON_LEGGINGS, 3).apply(new EnchantWithLevelsFunction(Items.IRON_LEGGINGS, 20, 39, true)),
+			new ItemEntry(Items.IRON_HELMET, 3).apply(new EnchantWithLevelsFunction(Items.IRON_HELMET, 20, 39, true)),
+			new ItemEntry(Items.IRON_PICKAXE, 3).apply(new EnchantWithLevelsFunction(Items.IRON_PICKAXE, 20, 39, true)),
+			new ItemEntry(Items.IRON_SHOVEL, 3).apply(new EnchantWithLevelsFunction(Items.IRON_SHOVEL, 20, 39, true)))
 	);
 
 	public static final LootTable IGLOO_CHEST_CHEST = new LootTable(
@@ -258,7 +261,7 @@ public class MCLootTables {
 			new ItemEntry(Items.IRON_HORSE_ARMOR),
 			new ItemEntry(Items.GOLDEN_HORSE_ARMOR),
 			new ItemEntry(Items.DIAMOND_HORSE_ARMOR),
-			new ItemEntry(Items.BOOK).apply(new EnchantWithLevelsFunction(30, 30, true)))
+			new ItemEntry(Items.BOOK).apply(new EnchantWithLevelsFunction(Items.BOOK, 30, 30, true)))
 	);
 
 	public static final LootTable JUNGLE_TEMPLE_DISPENSER_CHEST = new LootTable(
@@ -297,7 +300,7 @@ public class MCLootTables {
 			new ItemEntry(Items.ARROW, 4).apply(uniform(2.0F, 7.0F)),
 			new ItemEntry(Items.TRIPWIRE_HOOK, 3).apply(uniform(1.0F, 3.0F)),
 			new ItemEntry(Items.IRON_INGOT, 3).apply(uniform(1.0F, 3.0F)),
-			new ItemEntry(Items.ENCHANTED_BOOK).apply(new EnchantRandomlyFunction()))
+			new ItemEntry(Items.ENCHANTED_BOOK).apply(new EnchantRandomlyFunction(Items.ENCHANTED_BOOK)))
 	);
 
 	public static final LootTable RUINED_PORTAL_CHEST = new LootTable(
@@ -309,15 +312,15 @@ public class MCLootTables {
 			new ItemEntry(Items.FIRE_CHARGE, 40),
 			new ItemEntry(Items.GOLDEN_APPLE, 15),
 			new ItemEntry(Items.GOLD_NUGGET, 15).apply(uniform(4.0F, 24.0F)),
-			new ItemEntry(Items.GOLDEN_SWORD, 15).apply(new EnchantRandomlyFunction(true)),
-			new ItemEntry(Items.GOLDEN_AXE, 15).apply(new EnchantRandomlyFunction(true)),
-			new ItemEntry(Items.GOLDEN_HOE, 15).apply(new EnchantRandomlyFunction(true)),
-			new ItemEntry(Items.GOLDEN_SHOVEL, 15).apply(new EnchantRandomlyFunction(true)),
-			new ItemEntry(Items.GOLDEN_PICKAXE, 15).apply(new EnchantRandomlyFunction(true)),
-			new ItemEntry(Items.GOLDEN_BOOTS, 15).apply(new EnchantRandomlyFunction(true)),
-			new ItemEntry(Items.GOLDEN_CHESTPLATE, 15).apply(new EnchantRandomlyFunction(true)),
-			new ItemEntry(Items.GOLDEN_HELMET, 15).apply(new EnchantRandomlyFunction(true)),
-			new ItemEntry(Items.GOLDEN_LEGGINGS, 15).apply(new EnchantRandomlyFunction(true)),
+			new ItemEntry(Items.GOLDEN_SWORD, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_SWORD,true)),
+			new ItemEntry(Items.GOLDEN_AXE, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_AXE, true)),
+			new ItemEntry(Items.GOLDEN_HOE, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_HOE, true)),
+			new ItemEntry(Items.GOLDEN_SHOVEL, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_SHOVEL, true)),
+			new ItemEntry(Items.GOLDEN_PICKAXE, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_PICKAXE, true)),
+			new ItemEntry(Items.GOLDEN_BOOTS, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_BOOTS, true)),
+			new ItemEntry(Items.GOLDEN_CHESTPLATE, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_CHESTPLATE, true)),
+			new ItemEntry(Items.GOLDEN_HELMET, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_HELMET, true)),
+			new ItemEntry(Items.GOLDEN_LEGGINGS, 15).apply(new EnchantRandomlyFunction(Items.GOLDEN_LEGGINGS, true)),
 			new ItemEntry(Items.GLISTERING_MELON_SLICE, 5).apply(uniform(4.0F, 12.0F)),
 			new ItemEntry(Items.GOLDEN_HORSE_ARMOR, 5),
 			new ItemEntry(Items.LIGHT_WEIGHTED_PRESSURE_PLATE, 5),
@@ -367,10 +370,10 @@ public class MCLootTables {
 			new ItemEntry(Items.BAMBOO, 2).apply(uniform(1.0F, 3.0F)),
 			new ItemEntry(Items.GUNPOWDER, 3).apply(uniform(1.0F, 5.0F)),
 			new ItemEntry(Items.TNT).apply(uniform(1.0F, 2.0F)),
-			new ItemEntry(Items.LEATHER_HELMET, 3).apply(new EnchantRandomlyFunction()),
-			new ItemEntry(Items.LEATHER_CHESTPLATE, 3).apply(new EnchantRandomlyFunction()),
-			new ItemEntry(Items.LEATHER_LEGGINGS, 3).apply(new EnchantRandomlyFunction()),
-			new ItemEntry(Items.LEATHER_BOOTS, 3).apply(new EnchantRandomlyFunction()))
+			new ItemEntry(Items.LEATHER_HELMET, 3).apply(new EnchantRandomlyFunction(Items.LEATHER_HELMET)),
+			new ItemEntry(Items.LEATHER_CHESTPLATE, 3).apply(new EnchantRandomlyFunction(Items.LEATHER_CHESTPLATE)),
+			new ItemEntry(Items.LEATHER_LEGGINGS, 3).apply(new EnchantRandomlyFunction(Items.LEATHER_LEGGINGS)),
+			new ItemEntry(Items.LEATHER_BOOTS, 3).apply(new EnchantRandomlyFunction(Items.LEATHER_BOOTS)))
 	);
 
 	public static final LootTable SHIPWRECK_TREASURE_CHEST = new LootTable(
@@ -397,7 +400,7 @@ public class MCLootTables {
 			new ItemEntry(Items.GOLDEN_HORSE_ARMOR, 10),
 			new ItemEntry(Items.IRON_HORSE_ARMOR, 15),
 			new ItemEntry(Items.DIAMOND_HORSE_ARMOR, 5),
-			new ItemEntry(Items.ENCHANTED_BOOK, 10).apply(new EnchantRandomlyFunction())),
+			new ItemEntry(Items.ENCHANTED_BOOK, 10).apply(new EnchantRandomlyFunction(Items.ENCHANTED_BOOK))),
 		new LootPool(new UniformRoll(1.0F, 4.0F),
 			new ItemEntry(Items.IRON_INGOT, 10).apply(uniform(1.0F, 4.0F)),
 			new ItemEntry(Items.GOLD_INGOT, 5).apply(uniform(1.0F, 4.0F)),
@@ -458,7 +461,7 @@ public class MCLootTables {
 			new ItemEntry(Items.IRON_HORSE_ARMOR),
 			new ItemEntry(Items.GOLDEN_HORSE_ARMOR),
 			new ItemEntry(Items.DIAMOND_HORSE_ARMOR),
-			new ItemEntry(Items.BOOK).apply(new EnchantWithLevelsFunction(30, 30, true)))
+			new ItemEntry(Items.BOOK).apply(new EnchantWithLevelsFunction(Items.BOOK, 30, 30, true)))
 	);
 
 	public static final LootTable STRONGHOLD_CROSSING_CHEST = new LootTable(
@@ -470,7 +473,7 @@ public class MCLootTables {
 			new ItemEntry(Items.BREAD, 15).apply(uniform(1.0F, 3.0F)),
 			new ItemEntry(Items.APPLE, 15).apply(uniform(1.0F, 3.0F)),
 			new ItemEntry(Items.IRON_PICKAXE),
-			new ItemEntry(Items.BOOK).apply(new EnchantWithLevelsFunction(30, 30, true)))
+			new ItemEntry(Items.BOOK).apply(new EnchantWithLevelsFunction(Items.BOOK, 30, 30, true)))
 	);
 
 	public static final LootTable STRONGHOLD_LIBRARY_CHEST = new LootTable(
@@ -479,7 +482,7 @@ public class MCLootTables {
 			new ItemEntry(Items.PAPER, 20).apply(uniform(2.0F, 7.0F)),
 			new ItemEntry(Items.MAP),
 			new ItemEntry(Items.COMPASS),
-			new ItemEntry(Items.BOOK, 10).apply(new EnchantWithLevelsFunction(30, 30, true)))
+			new ItemEntry(Items.BOOK, 10).apply(new EnchantWithLevelsFunction(Items.BOOK, 30, 30, true)))
 	);
 
 	public static final LootTable UNDERWATER_RUIN_BIG_CHEST = new LootTable(
@@ -490,10 +493,10 @@ public class MCLootTables {
 			new ItemEntry(Items.WHEAT, 10).apply(uniform(2.0F, 3.0F))),
 		new LootPool(new ConstantRoll(1),
 			new ItemEntry(Items.GOLDEN_APPLE),
-			new ItemEntry(Items.ENCHANTED_BOOK, 5).apply(new EnchantRandomlyFunction()),
+			new ItemEntry(Items.ENCHANTED_BOOK, 5).apply(new EnchantRandomlyFunction(Items.ENCHANTED_BOOK)),
 			new ItemEntry(Items.LEATHER_CHESTPLATE),
 			new ItemEntry(Items.GOLDEN_HELMET),
-			new ItemEntry(Items.FISHING_ROD, 5).apply(new EnchantRandomlyFunction()),
+			new ItemEntry(Items.FISHING_ROD, 5).apply(new EnchantRandomlyFunction(Items.FISHING_ROD)),
 			new ItemEntry(Items.MAP, 10))
 	);
 
@@ -507,7 +510,7 @@ public class MCLootTables {
 		new LootPool(new ConstantRoll(1),
 			new ItemEntry(Items.LEATHER_CHESTPLATE),
 			new ItemEntry(Items.GOLDEN_HELMET),
-			new ItemEntry(Items.FISHING_ROD, 5).apply(new EnchantRandomlyFunction()),
+			new ItemEntry(Items.FISHING_ROD, 5).apply(new EnchantRandomlyFunction(Items.FISHING_ROD)),
 			new ItemEntry(Items.MAP, 5))
 	);
 
@@ -719,7 +722,7 @@ public class MCLootTables {
 			new ItemEntry(Items.CHAINMAIL_CHESTPLATE, 10),
 			new ItemEntry(Items.DIAMOND_HOE, 15),
 			new ItemEntry(Items.DIAMOND_CHESTPLATE, 5),
-			new ItemEntry(Items.ENCHANTED_BOOK, 10).apply(new EnchantRandomlyFunction())),
+			new ItemEntry(Items.ENCHANTED_BOOK, 10).apply(new EnchantRandomlyFunction(Items.ENCHANTED_BOOK))),
 		new LootPool(new UniformRoll(1.0F, 4.0F),
 			new ItemEntry(Items.IRON_INGOT, 10).apply(uniform(1.0F, 4.0F)),
 			new ItemEntry(Items.GOLD_INGOT, 5).apply(uniform(1.0F, 4.0F)),

--- a/src/main/java/kaptainwutax/featureutils/loot/enchantment/Enchantments.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/enchantment/Enchantments.java
@@ -1,14 +1,13 @@
 package kaptainwutax.featureutils.loot.enchantment;
 
-import kaptainwutax.featureutils.loot.item.ItemStack;
-import kaptainwutax.mcutils.version.MCVersion;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import kaptainwutax.featureutils.loot.item.ItemStack;
+import kaptainwutax.mcutils.version.MCVersion;
 
 public class Enchantments {
 	// @formatter:off
@@ -29,7 +28,7 @@ public class Enchantments {
 		addAll(BOOKS);
 		add("ELYTRA");
 	}};
-	public final static HashSet<String> ARMOR_LEGGINGS =new HashSet<String>() {{
+	public final static HashSet<String> ARMOR_LEGGINGS = new HashSet<String>() {{
 		for (String type : ARMOR_TYPES) {
 			add(type + "_LEGGINGS");
 		}
@@ -114,12 +113,12 @@ public class Enchantments {
 		addAll(SWORDS);
 		addAll(BOOKS);
 	}};
-	public final static HashSet<String> DAMAGE =new HashSet<String>() {{
+	public final static HashSet<String> DAMAGE = new HashSet<String>() {{
 		addAll(SWORDS);
 		addAll(AXES);
 		addAll(BOOKS);
 	}};
-	public final static HashSet<String> THORNS =new HashSet<String>() {{
+	public final static HashSet<String> THORNS = new HashSet<String>() {{
 		addAll(ARMOR);
 		remove("ELYTRA");
 	}};
@@ -133,51 +132,12 @@ public class Enchantments {
 	private final static Integer UNCOMMON = 5;
 	private final static Integer RARE = 2;
 	private final static Integer VERY_RARE = 1;
-	public static MCVersion Version = MCVersion.v1_16_1;
-	public List<Enchantment> EnchantmentRegistry;
+	//This needs to be set with apply
+	private static MCVersion version;
+	public static List<Enchantment> enchantmentRegistry = new ArrayList<>();
 
-	public Enchantments() {
-		this.EnchantmentRegistry = removeAllNull(new ArrayList<>(Arrays.asList(
-			new Enchantment("protection", COMMON, ARMOR, 1, 4, (i, n) -> (n < 1 + (i - 1) * 11), (i, n) -> (n > 1 + (i - 1) * 11 + 11), new HashSet<>(Arrays.asList("protection", "fire_protection", "projectile_protection", "blast_protection"))),
-			new Enchantment("fire_protection", UNCOMMON, ARMOR, 1, 4, (i, n) -> (n < 10 + (i - 1) * 8), (i, n) -> (n > 10 + (i - 1) * 8 + 8), new HashSet<>(Arrays.asList("protection", "fire_protection", "projectile_protection", "blast_protection"))),
-			new Enchantment("feather_falling", UNCOMMON, ARMOR_FEET, 1, 4, (i, n) -> (n < 5 + (i - 1) * 6), (i, n) -> (n > 5 + (i - 1) * 6 + 6), new HashSet<>(Arrays.asList("feather_falling"))),
-			new Enchantment("blast_protection", RARE, ARMOR, 1, 4, (i, n) -> (n < 5 + (i - 1) * 8), (i, n) -> (n > 5 + (i - 1) * 8 + 8), new HashSet<>(Arrays.asList("protection", "fire_protection", "projectile_protection", "blast_protection"))),
-			new Enchantment("projectile_protection", UNCOMMON, ARMOR, 1, 4, (i, n) -> (n < 3 + (i - 1) * 6), (i, n) -> (n > 3 + (i - 1) * 6 + 6), new HashSet<>(Arrays.asList("protection", "fire_protection", "projectile_protection", "blast_protection"))),
-			new Enchantment("respiration", RARE, ARMOR_HEAD, 1, 3, (i, n) -> (n < 10 * i), (i, n) -> (n > 10 * i + 30), new HashSet<>(Collections.singletonList("respiration"))),
-			new Enchantment("aqua_affinity", RARE, ARMOR_HEAD, 1, 1, (i, n) -> (n < 1), (i, n) -> (n > 41), new HashSet<>(Collections.singletonList("aqua_affinity"))),
-			new Enchantment("thorns", VERY_RARE, THORNS, 1, 3, (i, n) -> (n < 10 + (20 * (i - 1))), (i, n) -> (n > 10 + (20 * (i - 1)) + 50), new HashSet<>(Arrays.asList("thorns"))),
-			(Version.isNewerOrEqualTo(MCVersion.v1_8) ? new Enchantment("depth_strider", RARE, ARMOR_FEET, 1, 3, (i, n) -> (n < i * 10), (i, n) -> (n > i * 10 + 15), new HashSet<>(Arrays.asList("frost_walker", "depth_strider"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_9) ? new Enchantment("frost_walker", RARE, ARMOR_FEET, 1, 2, (i, n) -> (n < i * 10), (i, n) -> (n > i * 10 + 15), new HashSet<>(Arrays.asList("frost_walker", "depth_strider")), true) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_11) ? new Enchantment("binding_curse", VERY_RARE, ARMOR, 1, 1, (i, n) -> (n < 25), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("binding_curse")), true) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_16) ? new Enchantment("soul_speed", VERY_RARE, ARMOR_FEET, 1, 3, (i, n) -> (n < i * 10), (i, n) -> (n > i * 10 + 15), new HashSet<>(Arrays.asList("soul_speed")), true, false) : null),
-			new Enchantment("sharpness", COMMON, DAMAGE, 1, 5, (i, n) -> (n < 1 + (i - 1) * 11), (i, n) -> (n > 1 + (i - 1) * 11 + 20), new HashSet<>(Arrays.asList("sharpness", "smite", "bane_of_arthropods"))),
-			new Enchantment("smite", UNCOMMON, DAMAGE, 1, 5, (i, n) -> (n < 5 + (i - 1) * 8), (i, n) -> (n > 5 + (i - 1) * 8 + 20), new HashSet<>(Arrays.asList("sharpness", "smite", "bane_of_arthropods"))),
-			new Enchantment("bane_of_arthropods", UNCOMMON, DAMAGE, 1, 5, (i, n) -> (n < 5 + (i - 1) * 8), (i, n) -> (n > 5 + (i - 1) * 8 + 20), new HashSet<>(Arrays.asList("sharpness", "smite", "bane_of_arthropods"))),
-			new Enchantment("knockback", UNCOMMON, WEAPON, 1, 2, (i, n) -> (n < 5 + 20 * (i - 1)), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("knockback"))),
-			new Enchantment("fire_aspect", RARE, WEAPON, 1, 2, (i, n) -> (n < 10 + 20 * (i - 1)), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("fire_aspect"))),
-			new Enchantment("looting", RARE, WEAPON, 1, 3, (i, n) -> (n < 15 + (i - 1) * 9), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("looting", "silk_touch"))),
-			(Version.isNewerOrEqualTo(MCVersion.v1_11_1) ? new Enchantment("sweeping", RARE, WEAPON, 1, 3, (i, n) -> (n < 5 + (i - 1) * 9), (i, n) -> (n > 5 + (i - 1) * 9 + 15), new HashSet<>(Arrays.asList("sweeping"))) : null),
-			new Enchantment("efficiency", COMMON, DIGGER, 1, 5, (i, n) -> (n < (1 + 10 * (i - 1))), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("efficiency"))),
-			new Enchantment("silk_touch", VERY_RARE, DIGGER, 1, 1, (i, n) -> (n < 15), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("fortune", "silk_touch"))),
-			new Enchantment("unbreaking", UNCOMMON, BREAKABLE, 1, 3, (i, n) -> (n < 5 + (i - 1) * 8), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("unbreaking"))),
-			new Enchantment("fortune", RARE, DIGGER, 1, 3, (i, n) -> (n < 15 + (i - 1) * 9), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("fortune", "silk_touch"))),
-			new Enchantment("power", COMMON, BOW, 1, 5, (i, n) -> (n < 1 + (i - 1) * 10), (i, n) -> (n > 1 + (i - 1) * 10 + 15), new HashSet<>(Arrays.asList("power"))),
-			new Enchantment("punch", RARE, BOW, 1, 2, (i, n) -> (n < 12 + (i - 1) * 20), (i, n) -> (n > 12 + (i - 1) * 20 + 25), new HashSet<>(Arrays.asList("punch"))),
-			new Enchantment("flame", RARE, BOW, 1, 1, (i, n) -> (n < 20), (i, n) -> (n > 50), new HashSet<>(Collections.singletonList("flame"))),
-			new Enchantment("infinity", VERY_RARE, BOW, 1, 1, (i, n) -> (n < 20), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("mending", "infinity"))),
-			//The 1.8 is not correct, should be 1.7.2 but we don't have that so good enough
-			(Version.isNewerOrEqualTo(MCVersion.v1_8) ? new Enchantment("luck_of_the_sea", RARE, FISHING_ROD, 1, 3, (i, n) -> (n < 15 + (i - 1) * 9), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("luck_of_the_sea", "silk_touch"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_8) ? new Enchantment("lure", RARE, FISHING_ROD, 1, 3, (i, n) -> (n < 15 + (i - 1) * 9), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("lure"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_13) ? new Enchantment("loyalty", UNCOMMON, TRIDENT, 1, 3, (i, n) -> (n < 5 + (i * 7)), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("loyalty", "riptide"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_13) ? new Enchantment("impaling", RARE, TRIDENT, 1, 5, (i, n) -> (n < 1 + (i - 1) * 8), (i, n) -> (n > 1 + (i - 1) * 8 + 20), new HashSet<>(Arrays.asList("impaling"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_13) ? new Enchantment("riptide", RARE, TRIDENT, 1, 3, (i, n) -> (n < 10 + (i * 7)), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("riptide", "loyalty", "channeling"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_13) ? new Enchantment("channeling", VERY_RARE, TRIDENT, 1, 1, (i, n) -> (n < 25), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("channeling", "riptide"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_14) ? new Enchantment("multishot", RARE, CROSSBOW, 1, 1, (i, n) -> (n < 20), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("multishot", "piercing"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_14) ? new Enchantment("quick_charge", UNCOMMON, CROSSBOW, 1, 3, (i, n) -> (n < 12 + (i - 1) * 20), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("quick_charge"))) : null),
-			(Version.isNewerOrEqualTo(MCVersion.v1_14) ? new Enchantment("piercing", COMMON, CROSSBOW, 1, 4, (i, n) -> (n < 1 + (i - 1) * 10), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("multishot", "piercing"))) : null),
-			new Enchantment("mending", RARE, BREAKABLE, 1, 1, (i, n) -> (n < i * 25), (i, n) -> (n > i * 25 + 50), new HashSet<>(Arrays.asList("mending", "infinity")), true),
-			new Enchantment("vanishing_curse", VERY_RARE, VANISHABLE, 1, 1, (i, n) -> (n < 25), (i, n) -> (n > 50), new HashSet<>(Collections.singletonList("vanishing_curse")), true)
-		)));
+	static {
+		apply(MCVersion.v1_16_1);
 	}
 
 	public static boolean canApply(Enchantment enchantment, ItemStack item) {
@@ -189,8 +149,68 @@ public class Enchantments {
 		return list;
 	}
 
-	public static void setVersion(MCVersion v) {
-		Enchantments.Version = v;
+	public static void apply(MCVersion v) {
+		version = v;
+
+		enchantmentRegistry.add(new Enchantment("protection", COMMON, ARMOR, 1, 4, (i, n) -> (n < 1 + (i - 1) * 11), (i, n) -> (n > 1 + (i - 1) * 11 + 11), new HashSet<>(Arrays.asList("protection", "fire_protection", "projectile_protection", "blast_protection"))));
+		enchantmentRegistry.add(new Enchantment("fire_protection", UNCOMMON, ARMOR, 1, 4, (i, n) -> (n < 10 + (i - 1) * 8), (i, n) -> (n > 10 + (i - 1) * 8 + 8), new HashSet<>(Arrays.asList("protection", "fire_protection", "projectile_protection", "blast_protection"))));
+		enchantmentRegistry.add(new Enchantment("feather_falling", UNCOMMON, ARMOR_FEET, 1, 4, (i, n) -> (n < 5 + (i - 1) * 6), (i, n) -> (n > 5 + (i - 1) * 6 + 6), new HashSet<>(Arrays.asList("feather_falling"))));
+		enchantmentRegistry.add(new Enchantment("blast_protection", RARE, ARMOR, 1, 4, (i, n) -> (n < 5 + (i - 1) * 8), (i, n) -> (n > 5 + (i - 1) * 8 + 8), new HashSet<>(Arrays.asList("protection", "fire_protection", "projectile_protection", "blast_protection"))));
+		enchantmentRegistry.add(new Enchantment("projectile_protection", UNCOMMON, ARMOR, 1, 4, (i, n) -> (n < 3 + (i - 1) * 6), (i, n) -> (n > 3 + (i - 1) * 6 + 6), new HashSet<>(Arrays.asList("protection", "fire_protection", "projectile_protection", "blast_protection"))));
+		enchantmentRegistry.add(new Enchantment("respiration", RARE, ARMOR_HEAD, 1, 3, (i, n) -> (n < 10 * i), (i, n) -> (n > 10 * i + 30), new HashSet<>(Collections.singletonList("respiration"))));
+		enchantmentRegistry.add(new Enchantment("aqua_affinity", RARE, ARMOR_HEAD, 1, 1, (i, n) -> (n < 1), (i, n) -> (n > 41), new HashSet<>(Collections.singletonList("aqua_affinity"))));
+		enchantmentRegistry.add(new Enchantment("thorns", VERY_RARE, THORNS, 1, 3, (i, n) -> (n < 10 + (20 * (i - 1))), (i, n) -> (n > 10 + (20 * (i - 1)) + 50), new HashSet<>(Arrays.asList("thorns"))));
+
+		if (version.isNewerOrEqualTo(MCVersion.v1_8))
+			enchantmentRegistry.add(new Enchantment("depth_strider", RARE, ARMOR_FEET, 1, 3, (i, n) -> (n < i * 10), (i, n) -> (n > i * 10 + 15), new HashSet<>(Arrays.asList("frost_walker", "depth_strider"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_9))
+			enchantmentRegistry.add(new Enchantment("frost_walker", RARE, ARMOR_FEET, 1, 2, (i, n) -> (n < i * 10), (i, n) -> (n > i * 10 + 15), new HashSet<>(Arrays.asList("frost_walker", "depth_strider")), true));
+		if (version.isNewerOrEqualTo(MCVersion.v1_11))
+			enchantmentRegistry.add(new Enchantment("binding_curse", VERY_RARE, ARMOR, 1, 1, (i, n) -> (n < 25), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("binding_curse")), true));
+		if (version.isNewerOrEqualTo(MCVersion.v1_16))
+			enchantmentRegistry.add(new Enchantment("soul_speed", VERY_RARE, ARMOR_FEET, 1, 3, (i, n) -> (n < i * 10), (i, n) -> (n > i * 10 + 15), new HashSet<>(Arrays.asList("soul_speed")), true, false));
+
+		enchantmentRegistry.add(new Enchantment("sharpness", COMMON, DAMAGE, 1, 5, (i, n) -> (n < 1 + (i - 1) * 11), (i, n) -> (n > 1 + (i - 1) * 11 + 20), new HashSet<>(Arrays.asList("sharpness", "smite", "bane_of_arthropods"))));
+		enchantmentRegistry.add(new Enchantment("smite", UNCOMMON, DAMAGE, 1, 5, (i, n) -> (n < 5 + (i - 1) * 8), (i, n) -> (n > 5 + (i - 1) * 8 + 20), new HashSet<>(Arrays.asList("sharpness", "smite", "bane_of_arthropods"))));
+		enchantmentRegistry.add(new Enchantment("bane_of_arthropods", UNCOMMON, DAMAGE, 1, 5, (i, n) -> (n < 5 + (i - 1) * 8), (i, n) -> (n > 5 + (i - 1) * 8 + 20), new HashSet<>(Arrays.asList("sharpness", "smite", "bane_of_arthropods"))));
+		enchantmentRegistry.add(new Enchantment("knockback", UNCOMMON, WEAPON, 1, 2, (i, n) -> (n < 5 + 20 * (i - 1)), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("knockback"))));
+		enchantmentRegistry.add(new Enchantment("fire_aspect", RARE, WEAPON, 1, 2, (i, n) -> (n < 10 + 20 * (i - 1)), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("fire_aspect"))));
+		enchantmentRegistry.add(new Enchantment("looting", RARE, WEAPON, 1, 3, (i, n) -> (n < 15 + (i - 1) * 9), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("looting", "silk_touch"))));
+
+		if (version.isNewerOrEqualTo(MCVersion.v1_11_1))
+			enchantmentRegistry.add(new Enchantment("sweeping", RARE, WEAPON, 1, 3, (i, n) -> (n < 5 + (i - 1) * 9), (i, n) -> (n > 5 + (i - 1) * 9 + 15), new HashSet<>(Arrays.asList("sweeping"))));
+
+		enchantmentRegistry.add(new Enchantment("efficiency", COMMON, DIGGER, 1, 5, (i, n) -> (n < (1 + 10 * (i - 1))), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("efficiency"))));
+		enchantmentRegistry.add(new Enchantment("silk_touch", VERY_RARE, DIGGER, 1, 1, (i, n) -> (n < 15), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("fortune", "silk_touch"))));
+		enchantmentRegistry.add(new Enchantment("unbreaking", UNCOMMON, BREAKABLE, 1, 3, (i, n) -> (n < 5 + (i - 1) * 8), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("unbreaking"))));
+		enchantmentRegistry.add(new Enchantment("fortune", RARE, DIGGER, 1, 3, (i, n) -> (n < 15 + (i - 1) * 9), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("fortune", "silk_touch"))));
+		enchantmentRegistry.add(new Enchantment("power", COMMON, BOW, 1, 5, (i, n) -> (n < 1 + (i - 1) * 10), (i, n) -> (n > 1 + (i - 1) * 10 + 15), new HashSet<>(Arrays.asList("power"))));
+		enchantmentRegistry.add(new Enchantment("punch", RARE, BOW, 1, 2, (i, n) -> (n < 12 + (i - 1) * 20), (i, n) -> (n > 12 + (i - 1) * 20 + 25), new HashSet<>(Arrays.asList("punch"))));
+		enchantmentRegistry.add(new Enchantment("flame", RARE, BOW, 1, 1, (i, n) -> (n < 20), (i, n) -> (n > 50), new HashSet<>(Collections.singletonList("flame"))));
+		enchantmentRegistry.add(new Enchantment("infinity", VERY_RARE, BOW, 1, 1, (i, n) -> (n < 20), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("mending", "infinity"))));
+
+		//The 1.8 is not correct, should be 1.7.2 but we don't have that so good enough
+		if (version.isNewerOrEqualTo(MCVersion.v1_8))
+			enchantmentRegistry.add(new Enchantment("luck_of_the_sea", RARE, FISHING_ROD, 1, 3, (i, n) -> (n < 15 + (i - 1) * 9), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("luck_of_the_sea", "silk_touch"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_8))
+			enchantmentRegistry.add(new Enchantment("lure", RARE, FISHING_ROD, 1, 3, (i, n) -> (n < 15 + (i - 1) * 9), (i, n) -> (n > 1 + (i * 10) + 50), new HashSet<>(Arrays.asList("lure"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_13))
+			enchantmentRegistry.add(new Enchantment("loyalty", UNCOMMON, TRIDENT, 1, 3, (i, n) -> (n < 5 + (i * 7)), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("loyalty", "riptide"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_13))
+			enchantmentRegistry.add(new Enchantment("impaling", RARE, TRIDENT, 1, 5, (i, n) -> (n < 1 + (i - 1) * 8), (i, n) -> (n > 1 + (i - 1) * 8 + 20), new HashSet<>(Arrays.asList("impaling"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_13))
+			enchantmentRegistry.add(new Enchantment("riptide", RARE, TRIDENT, 1, 3, (i, n) -> (n < 10 + (i * 7)), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("riptide", "loyalty", "channeling"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_13))
+			enchantmentRegistry.add(new Enchantment("channeling", VERY_RARE, TRIDENT, 1, 1, (i, n) -> (n < 25), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("channeling", "riptide"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_14))
+			enchantmentRegistry.add(new Enchantment("multishot", RARE, CROSSBOW, 1, 1, (i, n) -> (n < 20), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("multishot", "piercing"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_14))
+			enchantmentRegistry.add(new Enchantment("quick_charge", UNCOMMON, CROSSBOW, 1, 3, (i, n) -> (n < 12 + (i - 1) * 20), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("quick_charge"))));
+		if (version.isNewerOrEqualTo(MCVersion.v1_14))
+			enchantmentRegistry.add(new Enchantment("piercing", COMMON, CROSSBOW, 1, 4, (i, n) -> (n < 1 + (i - 1) * 10), (i, n) -> (n > 50), new HashSet<>(Arrays.asList("multishot", "piercing"))));
+
+		enchantmentRegistry.add(new Enchantment("mending", RARE, BREAKABLE, 1, 1, (i, n) -> (n < i * 25), (i, n) -> (n > i * 25 + 50), new HashSet<>(Arrays.asList("mending", "infinity")), true));
+		enchantmentRegistry.add(new Enchantment("vanishing_curse", VERY_RARE, VANISHABLE, 1, 1, (i, n) -> (n < 25), (i, n) -> (n > 50), new HashSet<>(Collections.singletonList("vanishing_curse")), true));
 	}
 
 	public static HashSet<HashSet<String>> getCategories(ItemStack baseStack) {
@@ -214,7 +234,7 @@ public class Enchantments {
 	public static List<Enchantment> getApplicableEnchantments(HashSet<HashSet<String>> applicableCategories, boolean isTreasure, boolean isDiscoverable) {
 		List<Enchantment> applicableEnchantments = new ArrayList<>();
 		List<String> applicableEnchantmentNames = new ArrayList<>();
-		for(Enchantment currentEnchantment : new Enchantments().EnchantmentRegistry) {
+		for(Enchantment currentEnchantment : Enchantments.enchantmentRegistry) {
 			if((!currentEnchantment.isTreasure() || isTreasure) && (currentEnchantment.isDiscoverable() == isDiscoverable)) {
 				if(applicableCategories.contains(currentEnchantment.getCategory())) {
 					if(!(applicableEnchantmentNames.contains(currentEnchantment.getName()))) {
@@ -227,8 +247,8 @@ public class Enchantments {
 		return applicableEnchantments;
 	}
 
-	public static void filterCompatibleEnchantments(List<EnchantmentInstance> list, EnchantmentInstance instance) {
-		List<EnchantmentInstance> deepCopy = new ArrayList<>(list);
+	public static void filterCompatibleEnchantments(ArrayList<EnchantmentInstance> list, EnchantmentInstance instance) {
+		ArrayList<EnchantmentInstance> deepCopy = (ArrayList) list.clone();
 		for(EnchantmentInstance enchantmentInstance : deepCopy) {
 			if(enchantmentInstance.getIncompatible().contains(instance.getName()) || instance.getIncompatible().contains(enchantmentInstance.getName())) {
 				list.remove(enchantmentInstance);
@@ -237,7 +257,7 @@ public class Enchantments {
 	}
 
 	public Enchantment getEnchantment(String name) {
-		for(Enchantment enchantment : EnchantmentRegistry) {
+		for(Enchantment enchantment : enchantmentRegistry) {
 			if(enchantment.getName().equals(name)) {
 				return enchantment;
 			}
@@ -245,7 +265,7 @@ public class Enchantments {
 		return null;
 	}
 
-	public MCVersion getVersion(MCVersion v) {
-		return Enchantments.Version;
+	public static MCVersion getVersion() {
+		return version;
 	}
 }

--- a/src/main/java/kaptainwutax/featureutils/loot/entry/LootEntry.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/entry/LootEntry.java
@@ -42,8 +42,8 @@ public abstract class LootEntry extends LootGenerator {
 		return this.weight;
 	}
 
-	public int getEffectiveWeight(LootContext context) {
-		return Math.max(MathHelper.floor((float)this.weight + (float)this.quality * context.getLuck()), 0);
+	public int getEffectiveWeight(int luck) {
+		return Math.max(MathHelper.floor((float)this.weight + (float)this.quality * luck), 0);
 	}
 
 	public LootEntry apply(LootFunction... lootFunctions) {

--- a/src/main/java/kaptainwutax/featureutils/loot/function/EnchantRandomlyFunction.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/function/EnchantRandomlyFunction.java
@@ -1,5 +1,7 @@
 package kaptainwutax.featureutils.loot.function;
 
+import java.util.HashSet;
+import java.util.List;
 import kaptainwutax.featureutils.loot.LootContext;
 import kaptainwutax.featureutils.loot.enchantment.Enchantment;
 import kaptainwutax.featureutils.loot.enchantment.Enchantments;
@@ -7,27 +9,25 @@ import kaptainwutax.featureutils.loot.item.Item;
 import kaptainwutax.featureutils.loot.item.ItemStack;
 import kaptainwutax.mcutils.util.data.Pair;
 
-import java.util.HashSet;
-import java.util.List;
-
-import static kaptainwutax.featureutils.loot.enchantment.Enchantments.getApplicableEnchantments;
-import static kaptainwutax.featureutils.loot.enchantment.Enchantments.getCategories;
-
 public class EnchantRandomlyFunction implements LootFunction {
 	private boolean isTreasure;
 	private boolean isDiscoverable;
+	private List<Enchantment> applicableEnchantments;
 
-	public EnchantRandomlyFunction() {
-		this(true, true);
+	public EnchantRandomlyFunction(Item item) {
+		this(item, true, true);
 	}
 
-	public EnchantRandomlyFunction(boolean isTreasure) {
-		this(isTreasure, true);
+	public EnchantRandomlyFunction(Item item, boolean isTreasure) {
+		this(item, isTreasure, true);
 	}
 
-	public EnchantRandomlyFunction(boolean isTreasure, boolean isDiscoverable) {
+	public EnchantRandomlyFunction(Item item, boolean isTreasure, boolean isDiscoverable) {
 		this.isTreasure = isTreasure;
 		this.isDiscoverable = isDiscoverable;
+
+		HashSet<HashSet<String>> applicableCategories = Enchantments.getCategories(new ItemStack(item, 1));
+		this.applicableEnchantments = Enchantments.getApplicableEnchantments(applicableCategories, this.isTreasure, this.isDiscoverable);
 	}
 
 	public boolean isTreasure() {
@@ -48,9 +48,7 @@ public class EnchantRandomlyFunction implements LootFunction {
 
 	@Override
 	public ItemStack process(ItemStack baseStack, LootContext context) {
-		Item newItem = new Item(baseStack.getItem().getName());
-		HashSet<HashSet<String>> applicableCategories = getCategories(baseStack);
-		List<Enchantment> applicableEnchantments = getApplicableEnchantments(applicableCategories, this.isTreasure, this.isDiscoverable);
+		Item newItem = baseStack.getItem();
 		if(applicableEnchantments.isEmpty()) return baseStack;
 		int enchantNr = context.nextInt(applicableEnchantments.size());
 		Enchantment enchantment = applicableEnchantments.get(enchantNr);

--- a/src/main/java/kaptainwutax/featureutils/loot/function/EnchantWithLevelsFunction.java
+++ b/src/main/java/kaptainwutax/featureutils/loot/function/EnchantWithLevelsFunction.java
@@ -1,21 +1,16 @@
 package kaptainwutax.featureutils.loot.function;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import kaptainwutax.featureutils.loot.LootContext;
 import kaptainwutax.featureutils.loot.enchantment.Enchantment;
 import kaptainwutax.featureutils.loot.enchantment.EnchantmentInstance;
+import kaptainwutax.featureutils.loot.enchantment.Enchantments;
 import kaptainwutax.featureutils.loot.item.Item;
 import kaptainwutax.featureutils.loot.item.ItemStack;
 import kaptainwutax.mathutils.util.Mth;
 import kaptainwutax.mcutils.util.data.Pair;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
-import static kaptainwutax.featureutils.loot.enchantment.EnchantmentInstance.getRandomItem;
-import static kaptainwutax.featureutils.loot.enchantment.Enchantments.filterCompatibleEnchantments;
-import static kaptainwutax.featureutils.loot.enchantment.Enchantments.getApplicableEnchantments;
-import static kaptainwutax.featureutils.loot.enchantment.Enchantments.getCategories;
 
 public class EnchantWithLevelsFunction implements LootFunction {
 	private static final HashMap<String, Integer> enchantments;
@@ -23,6 +18,7 @@ public class EnchantWithLevelsFunction implements LootFunction {
 	private final int maxLevel;
 	private final boolean treasure;
 	private final boolean discoverable;
+	private final ArrayList<EnchantmentInstance>[] availableEnchantmentResults;
 
 	static {
 		enchantments = new HashMap<>();
@@ -85,19 +81,42 @@ public class EnchantWithLevelsFunction implements LootFunction {
 		enchantments.put("netherite_sword", 15);
 	}
 
-	public EnchantWithLevelsFunction(int minLevel, int maxLevel) {
-		this(minLevel, maxLevel, true, true);
+	public EnchantWithLevelsFunction(Item item, int minLevel, int maxLevel) {
+		this(item, minLevel, maxLevel, true, true);
 	}
 
-	public EnchantWithLevelsFunction(int minLevel, int maxLevel, boolean treasure) {
-		this(minLevel, maxLevel, treasure, true);
+	public EnchantWithLevelsFunction(Item item, int minLevel, int maxLevel, boolean treasure) {
+		this(item, minLevel, maxLevel, treasure, true);
 	}
 
-	public EnchantWithLevelsFunction(int minLevel, int maxLevel, boolean treasure, boolean discoverable) {
+	@SuppressWarnings("unchecked")
+	public EnchantWithLevelsFunction(Item item, int minLevel, int maxLevel, boolean treasure, boolean discoverable) {
 		this.minLevel = minLevel;
 		this.maxLevel = maxLevel;
 		this.treasure = treasure;
 		this.discoverable = discoverable;
+
+		int preprocessMaxLevel = ((int) (maxLevel * 2F));
+
+		this.availableEnchantmentResults = new ArrayList[preprocessMaxLevel];
+
+		for (int level = 0; level < preprocessMaxLevel; level++) {
+			ArrayList<EnchantmentInstance> res = new ArrayList<>();
+			List<Enchantment> list = Enchantments.getApplicableEnchantments(Enchantments.getCategories(new ItemStack(item)), this.treasure, this.discoverable);
+			for(Enchantment enchantment : list) {
+				if((!enchantment.isTreasure() || treasure) && enchantment.isDiscoverable() == discoverable) {
+					for(int i = enchantment.getMaxLevel(); i > enchantment.getMinLevel() - 1; i--) {
+						if(!enchantment.getIsLowerThanMinCost().test(i, level) && !enchantment.getIsHigherThanMaxCost().test(i, level)) {
+							res.add(new EnchantmentInstance(enchantment, i));
+							break;
+						}
+					}
+				}
+			}
+
+			this.availableEnchantmentResults[level] = res;
+		}
+
 	}
 
 	public ItemStack process(ItemStack itemStack, LootContext lootContext) {
@@ -124,33 +143,22 @@ public class EnchantWithLevelsFunction implements LootFunction {
 		level += 1 + lootContext.nextInt(enchantmentValue / 4 + 1) + lootContext.nextInt(enchantmentValue / 4 + 1);
 		float amplifier = (lootContext.nextFloat() + lootContext.nextFloat() - 1.0f) * 0.15f;
 		level = Mth.clamp(Math.round((float)level + (float)level * amplifier), 1, Integer.MAX_VALUE);
-		List<EnchantmentInstance> availableEnchantments = getAvailableEnchantmentResults(level, itemStack, isTreasure, isDiscoverable);
+		ArrayList<EnchantmentInstance> availableEnchantments = getAvailableEnchantmentResults(level);
 		if(!availableEnchantments.isEmpty()) {
-			res.add(getRandomItem(lootContext, availableEnchantments));
+			res.add(EnchantmentInstance.getRandomItem(lootContext, availableEnchantments));
 			while(lootContext.nextInt(50) <= level) {
-				filterCompatibleEnchantments(availableEnchantments, res.get(res.size() - 1));
+				Enchantments.filterCompatibleEnchantments(availableEnchantments, res.get(res.size() - 1));
 				if(availableEnchantments.isEmpty()) break;
-				res.add(getRandomItem(lootContext, availableEnchantments));
+				res.add(EnchantmentInstance.getRandomItem(lootContext, availableEnchantments));
 				level /= 2;
 			}
 		}
 		return res;
 	}
 
-	public List<EnchantmentInstance> getAvailableEnchantmentResults(int level, ItemStack itemStack, boolean isTreasure, boolean isDiscoverable) {
-		ArrayList<EnchantmentInstance> res = new ArrayList<>();
-		List<Enchantment> list = getApplicableEnchantments(getCategories(itemStack), this.treasure, this.discoverable);
-		for(Enchantment enchantment : list) {
-			if((!enchantment.isTreasure() || isTreasure) && enchantment.isDiscoverable() == isDiscoverable) {
-				for(int i = enchantment.getMaxLevel(); i > enchantment.getMinLevel() - 1; --i) {
-					if(!enchantment.getIsLowerThanMinCost().test(i, level) && !enchantment.getIsHigherThanMaxCost().test(i, level)) {
-						res.add(new EnchantmentInstance(enchantment, i));
-						break;
-					}
-				}
-			}
-		}
-		return res;
+	@SuppressWarnings("unchecked")
+	public ArrayList<EnchantmentInstance> getAvailableEnchantmentResults(int level) {
+		return (ArrayList<EnchantmentInstance>) this.availableEnchantmentResults[level].clone();
 	}
 
 	public int getRandomValueFromBounds(LootContext lootContext) {


### PR DESCRIPTION
All your tests run (apart from the spawn one but that didn't run to begin with) and we tested it for every single loot pool for 100k seeds, all had the exact same loot, but it is a lot faster.

Benchmarks:
- 1 item every loot table: same speed
- 1M items every loot table: 10x speed
- 1M items only Ruined Portal: 40x speed (it speeds up enchantments a lot)